### PR TITLE
Updated sharp to improve webp support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -79,6 +79,15 @@ stickers:
   # Whether or not to allow people to add custom sticker packs
   enabled: true
 
+  # Whether to resize images that are not 512x512 during import. This might slow down the import of animated Stickers.
+  resize: true
+
+  # Whether to allow animated stickers. If set to false animations will be stripped from images.
+  allowAnimated: true
+
+  # Whether to skip over images that are not 512x512. Ignored when resize is true.
+  verifyImageSize: true
+
   # The sticker manager bot to promote
   stickerBot: "@stickers:t2bot.io"
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "semver": "^7.3.5",
     "sequelize": "^6.12.0-alpha.1",
     "sequelize-typescript": "^2.1.1",
-    "sharp": "^0.29.0",
+    "sharp": "^0.30.7",
     "split-host": "^0.1.1",
     "spotify-uri": "^2.2.0",
     "sqlite3": "^5.0.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,9 @@ export interface DimensionConfig {
     };
     stickers: {
         enabled: boolean;
+        resize: boolean;
+        allowAnimated: boolean;
+        verifyImageSize: boolean;
         stickerBot: string;
         managerUrl: string;
     };

--- a/src/matrix/MatrixLiteClient.ts
+++ b/src/matrix/MatrixLiteClient.ts
@@ -159,7 +159,7 @@ export class MatrixLiteClient {
                 url: url,
                 encoding: null,
                 headers: {
-                    'Range': 'bytes=0-16'
+                    'Range': 'bytes=0-32'
                 },
             }, (err, res, _body) => {
                 if (err) {
@@ -179,17 +179,19 @@ export class MatrixLiteClient {
     }
 
     public parseFileHeaderMIME(data: Buffer): string {
-        const s = data.slice(0,12);
+        const s = data.slice(0,32);
         if (s.slice(0,8).includes(Buffer.from("89504E470D0A1A0A", "hex"))) {
             return("image/png");
         } else if (s.slice(0,3).includes(Buffer.from("474946", "hex"))) {
             return("image/gif");
         } else if (s.slice(0,3).includes(Buffer.from("FFD8FF", "hex"))) {
             return("image/jpeg");
-        } else if (s.slice(0,12).includes(Buffer.from("000000206674797061766966", "hex"))) {
-            return("image/avif");
-        } else if (s.slice(0,12).includes(Buffer.from("000000206674797061766973", "hex"))) {
-            return("image/avif-sequence");
+        } else if (s.slice(0,3).includes(Buffer.from("000000", "hex")) && s.slice(4,8).includes(Buffer.from("66747970", "hex"))) {
+            if (s.slice(16,28).includes(Buffer.from("61766973", "hex"))) {
+                return("image/avif-sequence");
+            } else if (s.slice(16,28).includes(Buffer.from("61766966", "hex"))) {
+                return("image/avif");
+            }
         } else if (s.slice(0,4).includes(Buffer.from("52494646", "hex")) && s.slice(8,12).includes(Buffer.from("57454250", "hex"))) {
             return("image/webp");
         }

--- a/src/matrix/MatrixLiteClient.ts
+++ b/src/matrix/MatrixLiteClient.ts
@@ -36,6 +36,15 @@ export class MatrixLiteClient {
         return baseUrl + `/_matrix/media/r0/thumbnail/${serverName}/${contentId}?width=${width}&height=${height}&method=${method}&animated=${isAnimated}`;
     }
 
+    public async getMediaUrl(serverName: string, contentId: string): Promise<string> {
+        let baseUrl = config.homeserver.mediaUrl;
+        if (!baseUrl) baseUrl = config.homeserver.clientServerUrl;
+        if (baseUrl.endsWith("/")) baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+
+        // DO NOT RETURN THE ACCESS TOKEN.
+        return baseUrl + `/_matrix/media/r0/download/${serverName}/${contentId}`;
+    }
+
     public async whoAmI(): Promise<string> {
         const response = await doClientApiCall(
             "GET",
@@ -106,6 +115,7 @@ export class MatrixLiteClient {
     }
 
     public async upload(content: Buffer, contentType: string): Promise<string> {
+        LogService.info("MatrixLiteClient", "Uploading file (type:" + contentType + ")");
         return doClientApiCall(
             "POST",
             "/_matrix/media/r0/upload",
@@ -126,6 +136,7 @@ export class MatrixLiteClient {
                 method: "GET",
                 url: url,
                 encoding: null,
+                headers: {},
             }, (err, res, _body) => {
                 if (err) {
                     LogService.error("MatrixLiteClient", "Error downloading file from " + url);
@@ -139,5 +150,49 @@ export class MatrixLiteClient {
                 }
             });
         });
+    }
+
+    public async parseMediaMIME(url: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            request({
+                method: "GET",
+                url: url,
+                encoding: null,
+                headers: {
+                    'Range': 'bytes=0-16'
+                },
+            }, (err, res, _body) => {
+                if (err) {
+                    LogService.error("MatrixLiteClient", "Error downloading file from " + url);
+                    LogService.error("MatrixLiteClient", err);
+                    reject(err);
+                } else if (res.statusCode !== 200) {
+                    if (res.statusCode !== 206) {
+                        LogService.error("MatrixLiteClient", "Got status code " + res.statusCode + " while calling url " + url);
+                        reject(new Error("Error in request: invalid status code"));
+                    }
+                } else {
+                    return this.parseFileHeaderMIME(res.body);
+                }
+            });
+        });
+    }
+
+    public parseFileHeaderMIME(data: Buffer): string {
+        const s = data.slice(0,12);
+        if (s.slice(0,8).includes(Buffer.from("89504E470D0A1A0A", "hex"))) {
+            return("image/png");
+        } else if (s.slice(0,3).includes(Buffer.from("474946", "hex"))) {
+            return("image/gif");
+        } else if (s.slice(0,3).includes(Buffer.from("FFD8FF", "hex"))) {
+            return("image/jpeg");
+        } else if (s.slice(0,12).includes(Buffer.from("000000206674797061766966", "hex"))) {
+            return("image/avif");
+        } else if (s.slice(0,12).includes(Buffer.from("000000206674797061766973", "hex"))) {
+            return("image/avif-sequence");
+        } else if (s.slice(0,4).includes(Buffer.from("52494646", "hex")) && s.slice(8,12).includes(Buffer.from("57454250", "hex"))) {
+            return("image/webp");
+        }
+        return;
     }
 }

--- a/src/matrix/MatrixStickerBot.ts
+++ b/src/matrix/MatrixStickerBot.ts
@@ -156,7 +156,7 @@ class _MatrixStickerBot {
                 }
                 if (mime === "image/jpeg") {
                     imageUpload = await resizedImage.clone().jpeg({quality: 80, chromaSubsampling: '4:4:4'}).toBuffer();
-                    thumbUpload = await resizedImage.avif({quality: 60, chromaSubsampling: '4:2:0'}).toBuffer();;
+                    thumbUpload = await resizedImage.jpeg({quality: 60, chromaSubsampling: '4:2:0'}).toBuffer();;
                 }
                 stickerEvent.contentUri = await mx.upload(imageUpload, mime);
                 stickerEvent.mimetype = mime;

--- a/src/matrix/MatrixStickerBot.ts
+++ b/src/matrix/MatrixStickerBot.ts
@@ -141,13 +141,13 @@ class _MatrixStickerBot {
                     thumbUpload = imageUpload;
                 }
                 if (mime === "image/gif" || mime === "image/webp" || mime === "image/avif-sequence") {
-                    imageUpload = await resizedImage.webp({nearLossless: true, quality: 60}).toBuffer();
+                    imageUpload = await resizedImage.webp({quality: 60, effort: 6}).toBuffer();
                     thumbUpload = await sharp(downImage, {animated: false}).resize({
                         width: size,
                         height: size,
                         fit: 'contain',
                         background: 'rgba(0,0,0,0)',
-                    }).webp({quality: 60}).toBuffer();
+                    }).webp({quality: 50}).toBuffer();
                     mime = "image/webp";
                 }
                 if (mime === "image/avif") {

--- a/web/app/shared/services/scalar/scalar-widget.api.ts
+++ b/web/app/shared/services/scalar/scalar-widget.api.ts
@@ -45,7 +45,7 @@ export class ScalarWidgetApi {
                 // Element Android requires content.body to contain the sticker description, otherwise
                 // you will not be able to send any stickers
                 body: sticker.description,
-                url: sticker.thumbnail.mxc,
+                url: sticker.image.mxc,
                 info: {
                     mimetype: sticker.image.mimetype,
                     w: Math.round(sticker.thumbnail.width / 2),


### PR DESCRIPTION
This includes the ability to enable or disable the resizing of oversized
images.
The ability to allow the upload of animated stickers.
The possibillity to disallow the upload of stickers that are not 512x512
when resizing is enabled